### PR TITLE
octave-matlab compatibility fix

### DIFF
--- a/bayesian_inversion.m
+++ b/bayesian_inversion.m
@@ -45,7 +45,7 @@ function bayesian_inversion(observations, vbr_predictions)
     %            for iz=1:nz ... Depth
     %  The order for the model parameters is T1, phi1, g1, T2, phi2, g2, ...
     %  Our total model space is (npts * number of physical parameters):
-    pars = ['T','phi','g'];    % set the free thermodynamic parameters in the inversion
+    pars = {'T'; 'phi'; 'g'};    % set the free thermodynamic parameters in the inversion
     npar = numel(pars); 
     nmod = npts*npar;
     ntype = 2; % number of observational datasets (Vs and Q)

--- a/run_with_low_res.m
+++ b/run_with_low_res.m
@@ -1,4 +1,7 @@
 % a lower resolution for quick calculation
+addpath('./functions')
+addpath('./inv_functions')
+addpath('./GLAD25')
 
 % load in the observations, limited by spatial extent
 spatial_sampling.elim = -10;

--- a/run_with_original_res.m
+++ b/run_with_original_res.m
@@ -1,5 +1,8 @@
 % should exactly reproduce run_invert_xfit_premelt.m, with the caveat that the results
 % end up in results/state_variables_xfit_premelt/
+addpath('./functions')
+addpath('./inv_functions')
+addpath('./GLAD25')
 
 % load in the observations, limited by spatial extent
 spatial_sampling.elim = -10.;     % eastern limit [decimal degrees; multiple of 0.5]


### PR DESCRIPTION
Small bug fix to improve octave compatibility. 

In octave, `pars = ['T','phi','g']` will concatenate to a string so that `numel(pars)=5` instead of 3. Changed it to a cell-array instead. 

Also added the path imports to the new `run_` files. 