### PR TITLE
make_vm optimization

### DIFF
--- a/inv_functions/make_Vm.m
+++ b/inv_functions/make_Vm.m
@@ -25,7 +25,7 @@ function Vm = make_Vm(std_T,std_phi,std_g,lscale,lats,lons,zs,npts,nmod)
         co_g(isite, :) = std_g(isite, isite) .* (std_g(isite, :) .* fac);
     end
 
-    # now assemble into expected form. 
+    % now assemble into expected form.
     Vm = zeros(nmod); % nmod = npts * npar (npar == 3)
 
     % note that if npar is ever not 3, this will fail.

--- a/inv_functions/make_Vm.m
+++ b/inv_functions/make_Vm.m
@@ -1,75 +1,77 @@
 %% INVERSION FUNCTIONS 4
 function Vm = make_Vm(std_T,std_phi,std_g,lscale,lats,lons,zs,npts,nmod)
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%
-% make_Vm = model covariance matrix
-%
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    %
+    % make_Vm = model covariance matrix
+    %
+    % the final covariance matrix will have a size of (nmod, nmod) with
+    % covariances for each parameter (T, phi, g) arranged in internal blocks.
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+    % get the cartesian grid at ever lat, lon zs permuation
+    [X, Y, Z] = get_cartesian_grid(lats, lons, zs);
 
-% make vectors of repeated lats and lons and zs
-vlats = zeros(npts,1);
-vlons = zeros(npts,1);
-vzs = zeros(npts,1);
-irow=1;
-for i=1:length(lats)
-    for j=1:length(lons)
-        for k=1:length(zs)
-            vlats(irow) = lats(i);
-            vlons(irow) = lons(j);
-            vzs(irow) = zs(k);
-            irow=irow+1;
-        end
+    % build the covariance matrix for each parameter
+    co_T = zeros(npts);
+    co_phi = zeros(npts);
+    co_g = zeros(npts);
+
+    for isite = 1:npts
+        d = get_dist(X(isite), Y(isite), Z(isite), X, Y, Z);
+        fac = transpose(exp(-abs(d)/lscale)(:));
+        std_facd =  std_T(isite, :) .* fac;
+        co_T(isite, :) = std_T(isite, isite) .* std_facd;
+        co_phi(isite, :) = std_phi(isite, isite) .* (std_phi(isite, :) .* fac);
+        co_g(isite, :) = std_g(isite, isite) .* (std_g(isite, :) .* fac);
     end
-end                  
-            
-Vm = zeros(nmod);
 
-for isite=1:npts
-    icol = 1;
-    for jsite=1:npts
-        irow = (isite-1)*3+1;
-        % each is a 3x3 subblock
-        d = get_dist(vlats(isite),vlats(jsite),vlons(isite),vlons(jsite),...
-            vzs(isite),vzs(jsite));
-        fac = exp(-abs(d)/lscale);
-        % T first:
-        val = std_T(isite)*std_T(jsite)*fac;
-        Vm(irow,icol) = val;
-        irow=irow+1;
-        icol=icol+1;
-        % phi second;
-        val = std_phi(isite)*std_phi(jsite)*fac;
-        Vm(irow,icol) = val;
-        irow=irow+1;
-        icol=icol+1;
-        % g third;
-        val = std_g(isite)*std_g(jsite)*fac;
-        Vm(irow,icol) = val;
-        icol=icol+1; 
-    end
-end
+    # now assemble into expected form. 
+    Vm = zeros(nmod); % nmod = npts * npar (npar == 3)
+
+    % note that if npar is ever not 3, this will fail.
+    npt_range = 1:npts;
+    icols = (npt_range - 1) * 3 + 1;
+    irows = (npt_range - 1) * 3 + 1;
+    Vm(irows, icols) = co_T;
+
+    icols = icols + 1;
+    irows = irows + 1;
+    Vm(irows, icols) = co_phi;
+
+    icols = icols + 1;
+    irows = irows + 1;
+    Vm(irows, icols) = co_g;
 
 end
 
+function [X, Y, Z] = get_cartesian_grid(lats, lons, zs)
+
+    % make vectors of repeated lats and lons and zs
+    [vlats, vlons, vzs] = ndgrid(lats, lons, zs);
+    vlats = permute(vlats, [3, 2, 1]);
+    vlons = permute(vlons, [3, 2, 1]);
+    vzs = permute(vzs, [3, 2, 1]);
+
+    % get the cartesian position of the full grid
+    [X, Y, Z] = geodesic_to_cart(vlats, vlons, vzs);
+
+end
+
+function [x, y, z] = geodesic_to_cart(lat, lon, depth)
+    % depth in km, lat/lon in deg
+    r = 6371. - depth;
+    x = r .* sind(90. - lat) .* cosd(lon);
+    y = r .* sind(90. - lat) .* sind(lon);
+    z = r .* cosd(90. - lat);
+end
 
 
-function d = get_dist(lat1,lat2,lon1,lon2,z1,z2)
+function d = get_dist(x1, y1, zz1, x2, y2, zz2)
 
-% z in km, lat/lon in deg
-r1 = 6371.-z1;
-r2 = 6371.-z2;
-x1 = r1*sind(90.-lat1)*cosd(lon1);
-y1 = r1*sind(90.-lat1)*sind(lon1);
-zz1 = r1*cosd(90.-lat1);
-x2 = r2*sind(90.-lat2)*cosd(lon2);
-y2 = r2*sind(90.-lat2)*sind(lon2);
-zz2 = r2*cosd(90.-lat2);
-
-dx = x2-x1;
-dy = y2-y1;
-dz = zz2-zz1;
-
-d = sqrt(dx*dx+dy*dy+dz*dz);
+    % get distance between the two points
+    dx = x2 - x1;
+    dy = y2 - y1;
+    dz = zz2 - zz1;
+    d = sqrt(dx.*dx+dy.*dy+dz.*dz);
 
 end

--- a/inv_functions/make_Vm.m
+++ b/inv_functions/make_Vm.m
@@ -24,7 +24,8 @@ function Vm = make_Vm(std_T,std_phi,std_g,lscale,lats,lons,zs,npts,nmod)
     % the distance between sites.
     for isite = 1:npts
         d = get_dist(X(isite), Y(isite), Z(isite), X, Y, Z);
-        fac = transpose(exp(-abs(d)/lscale)(:));  % the distance weighting
+        fac = exp(-abs(d)/lscale); % the distance weighting with all other sites
+        fac = transpose(fac(:)); % unwrap to 1d and transpose 
 
         irow = (isite - 1) * 3 + 1;
         Vm(irow, icols_T) = std_T(isite) .* std_T(isite, :) .* fac;

--- a/tests/call_a_test.m
+++ b/tests/call_a_test.m
@@ -41,7 +41,7 @@ function [time_diff, msg] = get_time_diff(expected_vals, current_vals, msg)
     frac = time_diff.absolute / expected_vals.elapsed_time;
     time_diff.percent = frac * 100;
 
-    if time_diff.absolute > 0
+    if time_diff.absolute < 0
         slow_fast = 'slower';
     else
         slow_fast = 'faster';


### PR DESCRIPTION
This PR speeds up `make_Vm` significantly, at least for octave. The `test_make_vm` test function went from taking ~3.8 s down to ~0.02 s. 

@guypaxman , since this is a change to how the code actually executes, I think it'd be good to make extra sure my changes here don't change the output for the high resolution run -- mind testing that out manually when you have a chance? I'd recommend trying to checkout the branch for this PR and trying it out before merging so that if I did break something we know before merging to main. Since these changes did pass the existing low resolution tests,  I'm 99.9% sure I didn't break anything.... but I'm paranoid. 

I'm also curious how much of a speed-up we get in matlab -- might be that the nested loops in `make_Vm` were more of an issue for octave. 